### PR TITLE
Do not display empty parens when WAY is not set

### DIFF
--- a/checkout_shipping.php
+++ b/checkout_shipping.php
@@ -126,8 +126,12 @@
             tep_session_unregister('shipping');
           } else {
             if ( (isset($quote[0]['methods'][0]['title'])) && (isset($quote[0]['methods'][0]['cost'])) ) {
+              $way = ''; 
+              if (!empty($quote[0]['methods'][0]['title'])) {
+                  $way = ' (' . $quote[0]['methods'][0]['title'] . ')'; 
+              }
               $shipping = array('id' => $shipping,
-                                'title' => (($free_shipping == true) ?  $quote[0]['methods'][0]['title'] : $quote[0]['module'] . ' (' . $quote[0]['methods'][0]['title'] . ')'),
+                                'title' => (($free_shipping == true) ?  $quote[0]['methods'][0]['title'] : $quote[0]['module'] . $way), 
                                 'cost' => $quote[0]['methods'][0]['cost']);
 
               tep_redirect(tep_href_link('checkout_payment.php', '', 'SSL'));


### PR DESCRIPTION
Fixes issue #766 

When the _WAY define for the associated shipping method is empty, no braces should be shown. 

Testing:
You MUST go back to the checkout shipping page to test  this change; you cannot simply refresh on the checkout confirmation page. 

Result:

![image](https://user-images.githubusercontent.com/4391638/62550430-3e097f80-b838-11e9-9bcc-c8db09643360.png)
