### PR TITLE
Moves base array for information box into core

### DIFF
--- a/includes/languages/english/modules/boxes/bm_information.php
+++ b/includes/languages/english/modules/boxes/bm_information.php
@@ -14,8 +14,10 @@
   define('MODULE_BOXES_INFORMATION_DESCRIPTION', 'Show information page links');
   define('MODULE_BOXES_INFORMATION_BOX_TITLE', 'Information');
   
-  define('MODULE_BOXES_INFORMATION_PRIVACY', 'Privacy Notice');
-  define('MODULE_BOXES_INFORMATION_CONDITIONS', 'Conditions of Use'); 
-  define('MODULE_BOXES_INFORMATION_SHIPPING',  'Shipping &amp; Returns');
-  define('MODULE_BOXES_INFORMATION_CONTACT_US', 'Contact Us'); 
-
+  const MODULE_BOXES_INFORMATION_BOX_DATA = array(
+    'privacy.php' => 'Privacy Notice',
+    'conditions.php' => 'Conditions of Use',
+    'shipping.php' => 'Shipping &amp; Returns',
+    'contact_us.php' => 'Contact Us'
+  );
+  

--- a/includes/languages/english/modules/boxes/bm_information.php
+++ b/includes/languages/english/modules/boxes/bm_information.php
@@ -19,9 +19,3 @@
   define('MODULE_BOXES_INFORMATION_SHIPPING',  'Shipping &amp; Returns');
   define('MODULE_BOXES_INFORMATION_CONTACT_US', 'Contact Us'); 
 
-  /* To define additional boxes, uncomment this block: 
-    define('MODULE_BOXES_INFORMATION_EXTRAS', array(
-      'your-box-filename.php','your-box-define',
-    )); 
-   *
-   */  

--- a/includes/languages/english/modules/boxes/bm_information.php
+++ b/includes/languages/english/modules/boxes/bm_information.php
@@ -14,10 +14,14 @@
   define('MODULE_BOXES_INFORMATION_DESCRIPTION', 'Show information page links');
   define('MODULE_BOXES_INFORMATION_BOX_TITLE', 'Information');
   
-  const MODULE_BOXES_INFORMATION_BOX_DATA = array(
-    'privacy.php' => 'Privacy Notice',
-    'conditions.php' => 'Conditions of Use',
-    'shipping.php' => 'Shipping &amp; Returns',
-    'contact_us.php' => 'Contact Us'
-  );
-  
+  define('MODULE_BOXES_INFORMATION_PRIVACY', 'Privacy Notice');
+  define('MODULE_BOXES_INFORMATION_CONDITIONS', 'Conditions of Use'); 
+  define('MODULE_BOXES_INFORMATION_SHIPPING',  'Shipping &amp; Returns');
+  define('MODULE_BOXES_INFORMATION_CONTACT_US', 'Contact Us'); 
+
+  /* To define additional boxes, uncomment this block: 
+    define('MODULE_BOXES_INFORMATION_EXTRAS', array(
+      'your-box-filename.php','your-box-define',
+    )); 
+   *
+   */  

--- a/includes/languages/english/modules/boxes/extras/bm_information_example.php
+++ b/includes/languages/english/modules/boxes/extras/bm_information_example.php
@@ -1,0 +1,12 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2018 osCommerce
+
+  Released under the GNU General Public License
+*/
+//  $information_box_list['some_example.php'] = 'Some Example Title'; 

--- a/includes/languages/english/modules/boxes/extras/bm_information_example.php
+++ b/includes/languages/english/modules/boxes/extras/bm_information_example.php
@@ -9,4 +9,4 @@
 
   Released under the GNU General Public License
 */
-//  $information_box_list['some_example.php'] = 'Some Example Title'; 
+$box_list['some_example.php'] = 'Some Example Title'; 

--- a/includes/modules/boxes/bm_information.php
+++ b/includes/modules/boxes/bm_information.php
@@ -32,9 +32,19 @@
 
     function execute() {
       global $oscTemplate;
-      
+
       $bm_information_links = null;      
-      foreach (MODULE_BOXES_INFORMATION_BOX_DATA as $a => $b) {
+
+      $box_list = array(
+        'privacy.php' => MODULE_BOXES_INFORMATION_PRIVACY, 
+        'conditions.php' => MODULE_BOXES_INFORMATION_CONDITIONS, 
+        'shipping.php' => MODULE_BOXES_INFORMATION_SHIPPING, 
+        'contact_us.php' => MODULE_BOXES_INFORMATION_CONTACT_US, 
+      );
+      if (defined('MODULE_BOXES_INFORMATION_EXTRAS')) {
+         $box_list = array_merge($box_list, MODULE_BOXES_INFORMATION_EXTRAS);
+      }
+      foreach ($box_list as $a => $b) {
         $bm_information_links .= '<a class="list-group-item list-group-item-action" href="' . tep_href_link($a) . '">' . $b . '</a>' . PHP_EOL; 
       }
 

--- a/includes/modules/boxes/bm_information.php
+++ b/includes/modules/boxes/bm_information.php
@@ -32,19 +32,26 @@
 
     function execute() {
       global $oscTemplate;
+      global $language; 
 
       $bm_information_links = null;      
 
-      $box_list = array(
+      $information_box_list = array(
         'privacy.php' => MODULE_BOXES_INFORMATION_PRIVACY, 
         'conditions.php' => MODULE_BOXES_INFORMATION_CONDITIONS, 
         'shipping.php' => MODULE_BOXES_INFORMATION_SHIPPING, 
         'contact_us.php' => MODULE_BOXES_INFORMATION_CONTACT_US, 
       );
-      if (defined('MODULE_BOXES_INFORMATION_EXTRAS')) {
-         $box_list = array_merge($box_list, MODULE_BOXES_INFORMATION_EXTRAS);
+      $dir = 'includes/languages/' . $language . '/modules/boxes/extras/'; 
+      if ($dh = opendir($dir)) { 
+        while (($file = readdir($dh)) !== false){
+          if (strncmp(basename($file,".php"), basename(__FILE__, ".php"), strlen(basename(__FILE__, ".php"))) == 0) {
+             require($dir . $file); 
+          }
+        }
+        closedir($dh);
       }
-      foreach ($box_list as $a => $b) {
+      foreach ($information_box_list as $a => $b) {
         $bm_information_links .= '<a class="list-group-item list-group-item-action" href="' . tep_href_link($a) . '">' . $b . '</a>' . PHP_EOL; 
       }
 

--- a/includes/modules/boxes/bm_information.php
+++ b/includes/modules/boxes/bm_information.php
@@ -36,22 +36,19 @@
 
       $bm_information_links = null;      
 
-      $information_box_list = array(
-        'privacy.php' => MODULE_BOXES_INFORMATION_PRIVACY, 
-        'conditions.php' => MODULE_BOXES_INFORMATION_CONDITIONS, 
-        'shipping.php' => MODULE_BOXES_INFORMATION_SHIPPING, 
-        'contact_us.php' => MODULE_BOXES_INFORMATION_CONTACT_US, 
-      );
+      $box_list = MODULE_BOXES_INFORMATION_BOX_DATA; 
+
+      $box_name = basename(__FILE__, ".php"); 
       $dir = 'includes/languages/' . $language . '/modules/boxes/extras/'; 
       if ($dh = opendir($dir)) { 
         while (($file = readdir($dh)) !== false){
-          if (strncmp(basename($file,".php"), basename(__FILE__, ".php"), strlen(basename(__FILE__, ".php"))) == 0) {
+          if (strncmp(basename($file,".php"), $box_name, strlen($box_name)) == 0) {
              require($dir . $file); 
           }
         }
         closedir($dh);
       }
-      foreach ($information_box_list as $a => $b) {
+      foreach ($box_list as $a => $b) {
         $bm_information_links .= '<a class="list-group-item list-group-item-action" href="' . tep_href_link($a) . '">' . $b . '</a>' . PHP_EOL; 
       }
 


### PR DESCRIPTION
Fixes #775 

Moving the base array out of the language file sets the stage for making it easier to extend. 

**Test plan (required)**
- Tested box with no extension - box has 4 entries as expected. 
Added to box by changing includes/languages/english/modules/boxes/extras/bm_information_example.php to uncomment out the last line to 
```
$information_box_list['better_together_promo.php'] = 'Better Together Offers';
```
in language file.  Box now has 5 entries. 

