### PR TITLE
Set up application before registering hooks

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -58,8 +58,8 @@
 // hooks
   require('includes/classes/hooks.php');
   $OSCOM_Hooks = new hooks('shop');
-  $OSCOM_Hooks->register('siteWide');
-  $OSCOM_Hooks->call('siteWide', 'startApplication');
+  $OSCOM_Hooks->register('system');
+  $OSCOM_Hooks->call('system', 'startApplication');
 
 // set the application parameters
   $configuration_query = tep_db_query('select configuration_key as cfgKey, configuration_value as cfgValue from configuration');
@@ -410,6 +410,7 @@
     }
   }
 
+  $OSCOM_Hooks->register('siteWide');
   $OSCOM_Hooks->call('siteWide', 'injectAppTop');
 
   $OSCOM_Hooks->register(basename($PHP_SELF, '.php'));


### PR DESCRIPTION
The siteWide hooks sometimes need the setup from application_top.php when used with third-party Apps.  So return their register invocation to the original place and make the new location use a different group.

Please provide enough information in your raised ISSUE so that others can understand and review the details of your Test Plan:

Explain the **details** for making this change. What existing problem does the pull request solve?
Example: When "Adding a function to do X", explain why it is necessary to have a way to do X.

**Test plan (required)**

This change has already been tested at https://forums.oscommerce.com/topic/494447-v1040/?tab=comments#comment-1798977

The other way was breaking third-party Apps.  