### PR TITLE
Catalog autoloader

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -49,6 +49,10 @@
     define('DIR_WS_CATALOG', DIR_WS_HTTPS_CATALOG);
   }
 
+// autoload classes under the classes or modules directories
+  require 'includes/functions/autoloader.php';
+  spl_autoload_register('tep_autoload_catalog');
+
 // include the database functions
   require('includes/functions/database.php');
 

--- a/includes/classes/autoloader.php
+++ b/includes/classes/autoloader.php
@@ -1,0 +1,71 @@
+<?php
+/*
+  $Id$
+
+  osCommerce, Open Source E-Commerce Solutions
+  http://www.oscommerce.com
+
+  Copyright (c) 2019 osCommerce
+
+  Released under the GNU General Public License
+*/
+
+  function tep_find_all_files_under($directory, &$files) {
+    $current_entries = scandir($directory);
+
+    foreach ($current_entries as $entry) {
+      // we have no file or directory names starting with a dot
+      // so it's safe to screen out anything that does, like the current and parent directories
+      if ('.' === $entry[0]) {
+        continue;
+      }
+
+      $path = "$directory/$entry";
+      if (is_file($path)) {
+        $files[pathinfo($entry, PATHINFO_FILENAME)] = $path;
+      } elseif (is_dir($path) && 'cc_braintree' != $entry && 'templates' != $entry) {
+        // templates directories are underneath the modules directory but do not contain classes
+        // cc_braintree uses its own naming convention, so we make it load its own classes
+        tep_find_all_files_under($path, $files);
+      }
+    }
+  }
+
+  function tep_autoload_catalog($class) {
+    static $class_files;
+    static $modules_directory_length;
+
+    if (!isset($class_files)) {
+      $modules_directory_length = strlen(DIR_FS_CATALOG . 'includes/modules');
+      $class_files = [];
+
+      tep_find_all_files_under(DIR_FS_CATALOG . 'includes/hooks', $class_files);
+      tep_find_all_files_under(DIR_FS_CATALOG . 'includes/modules', $class_files);
+      tep_find_all_files_under(DIR_FS_CATALOG . 'includes/classes', $class_files);
+
+      // some classes do not follow either naming standard relating the class name and file name
+      $exception_mappings = [
+        'alert_block' => 'alertbox',
+        'os_c__actions' => 'actions',
+        'm_c_a_p_i' => 'MCAPI.class',
+      ];
+      foreach ($exception_mappings as $class_name => $filename) {
+        $class_files[$class_name] = $class_files[$filename];
+        unset($class_files[$filename]);
+      }
+    }
+
+    // convert camelCase class names to snake_case filenames
+    $class = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $class));
+
+    if (isset($class_files[$class])) {
+      if (isset($GLOBALS['language']) && DIR_FS_CATALOG . 'includes/modules' === substr($class_files[$class], 0, $modules_directory_length)) {
+        $language_file = DIR_FS_CATALOG . 'includes/languages/'. $GLOBALS['language'] . '/modules' . substr($class_files[$class], $modules_directory_length);
+        if (file_exists($language_file)) {
+          include $language_file;
+        }
+      }
+
+      require $class_files[$class];
+    }
+  }


### PR DESCRIPTION
This change adds an autoloader for the catalog side of the shop.

I have tested it by removing the class includes from application_top.php and navigating a test site (without testing checkout, login, or registration, but some modules already started using it).

My suggestion would be that we don't try to make that change now.  Instead, IMO, we should release this with a build point release (e.g. 1.0.4.1) as is and see if it causes any issues.  We can update application_top.php to not manually include class files after the next patch release (1.0.5.0, so for 1.0.5.1 or later) as part of other changes.  Also we could change the module loading then so that all of them use the autoloader and remove the redundant loading code.  

If you want me to do more testing before this change, let me know.  I'd just have to make a new test site, which is not so difficult.  But my current testing at least shows that it is sane.  

We also might consider making some naming changes to simplify the autoloader logic.  For example, we could move the cc_braintree directory and ht_mailchimp_360 directory to apps alongside PayPal.  We could change the names of alertBlock to alertbox and osC_Actions to actions to match the current filenames.  We could rename camelCase classes to snake_case to match the filenames.  And of course, we could start namespacing classes.  