### PR TITLE
Prepare for hooked includes

### DIFF
--- a/admin/includes/application_top.php
+++ b/admin/includes/application_top.php
@@ -27,11 +27,25 @@
     include('includes/configure.php');
   }
 
+// include the list of project database tables
+  require('includes/database_tables.php');
+
+// set default timezone if none exists (PHP 5.3 throws an E_WARNING)
+  date_default_timezone_set(defined('CFG_TIME_ZONE') ? CFG_TIME_ZONE : date_default_timezone_get());
+
+// include the database functions
+  require('includes/functions/database.php');
+
+// make a connection to the database... now
+  tep_db_connect() or die('Unable to connect to database server!');
+
+  require DIR_FS_CATALOG . 'includes/classes/hooks.php';
+  $OSCOM_Hooks = new hooks('admin');
+  $OSCOM_Hooks->register('system');
+  $OSCOM_Hooks->generate('system', 'startApplication');
+
 // Define the project version --- obsolete, now retrieved with tep_get_version()
   define('PROJECT_VERSION', 'OSCOM CE Phoenix');
-
-// some code to solve compatibility issues
-  require('includes/functions/compatibility.php');
 
 // set the type of request (secure or not)
   $request_type = (getenv('HTTPS') == 'on') ? 'SSL' : 'NONSSL';
@@ -46,17 +60,8 @@
   define('LOCAL_EXE_ZIP', 'zip');
   define('LOCAL_EXE_UNZIP', 'unzip');
 
-// include the list of project database tables
-  require('includes/database_tables.php');
-
-// include the database functions
-  require('includes/functions/database.php');
-
-// make a connection to the database... now
-  tep_db_connect() or die('Unable to connect to database server!');
-
 // set application wide parameters
-  $configuration_query = tep_db_query('select configuration_key as cfgKey, configuration_value as cfgValue from ' . TABLE_CONFIGURATION);
+  $configuration_query = tep_db_query('select configuration_key as cfgKey, configuration_value as cfgValue from configuration');
   while ($configuration = tep_db_fetch_array($configuration_query)) {
     define($configuration['cfgKey'], $configuration['cfgValue']);
   }
@@ -214,9 +219,6 @@
 // initialize configuration modules
   require('includes/classes/cfg_modules.php');
   $cfgModules = new cfg_modules();
-
-  require(DIR_FS_CATALOG . 'includes/classes/hooks.php');
-  $OSCOM_Hooks = new hooks('admin');
 
   $OSCOM_Hooks->register('siteWide');
 

--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -60,10 +60,10 @@
   tep_db_connect() or die('Unable to connect to database server!');
 
 // hooks
-  require('includes/classes/hooks.php');
+  require 'includes/classes/hooks.php';
   $OSCOM_Hooks = new hooks('shop');
   $OSCOM_Hooks->register('system');
-  $OSCOM_Hooks->call('system', 'startApplication');
+  $OSCOM_Hooks->generate('system', 'startApplication');
 
 // set the application parameters
   $configuration_query = tep_db_query('select configuration_key as cfgKey, configuration_value as cfgValue from configuration');


### PR DESCRIPTION
Add generate function in hooks class and some general code cleanup.  

Move hook creation higher in admin/includes/application_top.php to match catalog.  Make both use the generate function.  

Move defines and SSL/PHP_SELF configuration after the first hookpoint.  

Eliminate compatibility functions except for setting timezone.  

Remove use of deprecated TABLE_CONFIGURATION.

This is the code that I've been using on my test site.  