### PR TITLE
Change to match the language file

### DIFF
--- a/checkout_payment.php
+++ b/checkout_payment.php
@@ -194,7 +194,7 @@
   ?>
 
   <div class="buttonSet">
-    <div class="text-right"><?php echo tep_draw_button(TITLE_CONTINUE_CHECKOUT_PROCEDURE, 'fas fa-angle-right', null, 'primary', null, 'btn-success btn-lg btn-block'); ?></div>
+    <div class="text-right"><?php echo tep_draw_button(BUTTON_CONTINUE_CHECKOUT_PROCEDURE, 'fas fa-angle-right', null, 'primary', null, 'btn-success btn-lg btn-block'); ?></div>
   </div>
 
   <div class="progressBarHook">


### PR DESCRIPTION
In the language file, there is a BUTTON_CONTINUE_CHECKOUT_PROCEDURE but no TITLE_CONTINUE_CHECKOUT_PROCEDURE.  So changing this file to match the language file as well as other files like checkout_shipping.php

I haven't tested this, but it is currently broken and would not be more broken.  

https://github.com/gburton/CE-Phoenix/issues/874