### PR TITLE
Remove unnecessary array_keys

### DIFF
--- a/admin/includes/classes/shopping_cart.php
+++ b/admin/includes/classes/shopping_cart.php
@@ -212,7 +212,7 @@
 
 // attributes price
         if (isset($this->contents[$products_id]['attributes'])) {
-          foreach (array_keys($this->contents[$products_id]['attributes']) as $option => $value) {
+          foreach ($this->contents[$products_id]['attributes'] as $option => $value) {
             $attribute_price_query = tep_db_query("select options_values_price, price_prefix from " . TABLE_PRODUCTS_ATTRIBUTES . " where products_id = '" . (int)$prid . "' and options_id = '" . (int)$option . "' and options_values_id = '" . (int)$value . "'");
             $attribute_price = tep_db_fetch_array($attribute_price_query);
             if ($attribute_price['price_prefix'] == '+') {


### PR DESCRIPTION
Fix (copy and paste?) error.  Reported and tested in the forums at https://forums.oscommerce.com/topic/494736-whileeach-update-to-foreach-issue/

I actually think this file could be deleted, since the autoloader will load the catalog version if the admin version is not there.  But it might as well be correct first.  
