### PR TITLE
Immediate term proposal for error handling

### DIFF
--- a/account_edit.php
+++ b/account_edit.php
@@ -56,6 +56,7 @@
 
   <?php
   $customer_data->display_input($customer_data->get_fields_for_page('account_edit'), $customer->fetch_to_address());
+  echo $OSCOM_Hooks->call('siteWide', 'injectFormDisplay');
   ?>
 
   <div class="buttonSet">

--- a/includes/functions/general.php
+++ b/includes/functions/general.php
@@ -1033,3 +1033,25 @@
 
     return ($matched && ($formid == $sessiontoken));
   }
+
+  /**
+   * For use by injectFormVerify hooks and Apps that need to block form processing.
+   */
+  function tep_block_form_processing() {
+    switch ($GLOBALS['PHP_SELF']) {
+      case 'account_edit.php':
+      case 'customer_account.php':
+      case 'password_reset.php':
+        unset($GLOBALS['customer_details']);
+        break;
+      case 'address_book_process.php':
+      case 'checkout_shipping_address.php':
+      case 'checkout_payment_address.php':
+        $GLOBALS['customer_details'] = false;
+        break;
+      case 'advanced_search_result.php':
+      case 'contact_us.php':
+      default:
+        $GLOBALS['error'] = true;
+    }
+  }

--- a/password_reset.php
+++ b/password_reset.php
@@ -61,6 +61,7 @@
 
   if (tep_validate_form_action_is('process')) {
     $customer_details = $customer_data->process($page_fields);
+    $OSCOM_Hooks->call('siteWide', 'injectFormVerify');
 
     if (!empty($customer_details)) {
       $customer_data->update(['password' => $customer_data->get('password', $customer_details)], ['id' => (int)$customer_data->get('id', $check_customer)]);
@@ -92,6 +93,7 @@
   
   <?php
   $customer_data->display_input($page_fields);
+  echo $OSCOM_Hooks->call('siteWide', 'injectFormDisplay');
   ?>
   
   <div class="buttonSet">


### PR DESCRIPTION
As per an outside discussion, it is necessary for hooks/Apps to have a standard way of blocking form processing.  This would allow any hook/App to call a standard function `tep_block_form_processing()` which then figures out how to block processing for that page.  

Also adds hook points on two pages that did not previously have them for consistency with other pages that do.  