### PR TITLE
Update for Apache 2.4 compatible with 2.2

### DIFF
--- a/admin/backups/.htaccess
+++ b/admin/backups/.htaccess
@@ -19,6 +19,12 @@
 Options -Indexes
 
 <Files *>
-Order Deny,Allow
-Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>

--- a/admin/images/.htaccess
+++ b/admin/images/.htaccess
@@ -5,6 +5,12 @@
 
 # Prevents any script files from being accessed from the images folder
 <FilesMatch "\.(php([0-9]|s)?|s?p?html|cgi|pl|exe)$">
-   Order Deny,Allow
-   Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </FilesMatch>

--- a/admin/includes/.htaccess
+++ b/admin/includes/.htaccess
@@ -17,6 +17,12 @@
 # Example: http://server/catalog/admin/includes/application_top.php will not work
 
 <Files *.php>
-Order Deny,Allow
-Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>

--- a/images/.htaccess
+++ b/images/.htaccess
@@ -5,8 +5,14 @@
 
 # Prevents any script files from being accessed from the images folder
 <FilesMatch "\.(php([0-9]|s)?|s?p?html|cgi|pl|exe)$">
-   Order Deny,Allow
-   Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </FilesMatch>
 
 Options -Indexes

--- a/includes/.htaccess
+++ b/includes/.htaccess
@@ -17,6 +17,12 @@
 # Example: http://server/catalog/includes/application_top.php will not work
 
 <Files *.php>
-Order Deny,Allow
-Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>

--- a/includes/work/.htaccess
+++ b/includes/work/.htaccess
@@ -1,4 +1,10 @@
 <Files *>
-  Order Deny,Allow
-  Deny from all
+  <IfModule mod_authz_core.c>
+    Require all denied
+  </IfModule>
+
+  <IfModule !mod_authz_core.c>
+    Order Deny,Allow
+    Deny from all
+  </IfModule>
 </Files>


### PR DESCRIPTION
Resolve https://github.com/gburton/CE-Phoenix/issues/900

This retains the existing configuration for sites using Apache 2.2 or older but uses the newer configuration if available (in 2.4 or later).  

Tested by entering the configuration into the httpd.conf file in a 2.4 site.  Not tested in the .htaccess files nor on an Apache 2.2 site.  