### PR TITLE
Prepare to deprecate admin order class

### DIFF
--- a/admin/includes/classes/order.php
+++ b/admin/includes/classes/order.php
@@ -5,113 +5,129 @@
   osCommerce, Open Source E-Commerce Solutions
   http://www.oscommerce.com
 
-  Copyright (c) 2014 osCommerce
+  Copyright (c) 2020 osCommerce
 
   Released under the GNU General Public License
 */
 
   class order {
-    var $info, $totals, $products, $customer, $delivery;
 
-    function __construct($order_id) {
-      $this->info = array();
-      $this->totals = array();
-      $this->products = array();
-      $this->customer = array();
-      $this->delivery = array();
+    public $info, $totals, $products, $customer, $delivery, $content_type;
+
+    public function __construct($order_id) {
+      $this->info = [];
+      $this->totals = [];
+      $this->products = [];
+      $this->customer = [];
+      $this->delivery = [];
 
       $this->query($order_id);
     }
 
-    function query($order_id) {
+    public function query($order_id) {
       global $languages_id;
 
-      $order_query = tep_db_query("select o.*, s.orders_status_name from " . TABLE_ORDERS . " o, " . TABLE_ORDERS_STATUS . " s where o.orders_id = '" . (int)$order_id . "' and o.orders_status = s.orders_status_id and s.language_id = '" . (int)$languages_id . "'");
+      $order_id = tep_db_prepare_input($order_id);
+
+      $order_query = tep_db_query("SELECT * FROM orders WHERE orders_id = " . (int)$order_id);
       $order = tep_db_fetch_array($order_query);
 
-      $totals_query = tep_db_query("select title, text, class from " . TABLE_ORDERS_TOTAL . " where orders_id = '" . (int)$order_id . "' order by sort_order");
+      $totals_query = tep_db_query("SELECT title, text FROM orders_total WHERE orders_id = " . (int)$order_id . " ORDER BY sort_order");
       while ($totals = tep_db_fetch_array($totals_query)) {
-        $this->totals[] = array('title' => $totals['title'],
-                                'text' => $totals['text'],
-                                'class' => $totals['class']);
+        $this->totals[] =  [
+          'title' => $totals['title'],
+          'text' => $totals['text'],
+        ];
       }
 
-      $this->info = array('total' => null,
-                          'currency' => $order['currency'],
-                          'currency_value' => $order['currency_value'],
-                          'payment_method' => $order['payment_method'],
-                          'cc_type' => $order['cc_type'],
-                          'cc_owner' => $order['cc_owner'],
-                          'cc_number' => $order['cc_number'],
-                          'cc_expires' => $order['cc_expires'],
-                          'date_purchased' => $order['date_purchased'],
-                          'status' => $order['orders_status_name'],
-                          'orders_status' => $order['orders_status'],
-                          'last_modified' => $order['last_modified']);
+      $order_total_query = tep_db_query("SELECT text FROM orders_total WHERE orders_id = " . (int)$order_id . " AND class = 'ot_total'");
+      $order_total = tep_db_fetch_array($order_total_query);
 
-      foreach ( $this->totals as $t ) {
-        if ( $t['class'] == 'ot_total' ) {
-          $this->info['total'] = $t['text'];
-          break;
-        }
+      $shipping_method_query = tep_db_query("SELECT title FROM orders_total WHERE orders_id = " . (int)$order_id . " AND class = 'ot_shipping'");
+      $shipping_method = tep_db_fetch_array($shipping_method_query);
+
+      $order_status_query = tep_db_query("SELECT orders_status_name FROM orders_status WHERE orders_status_id = " . $order['orders_status'] . " AND language_id = " . (int)$languages_id);
+      $order_status = tep_db_fetch_array($order_status_query);
+
+      $this->info = [
+        'currency' => $order['currency'],
+        'currency_value' => $order['currency_value'],
+        'payment_method' => $order['payment_method'],
+        'date_purchased' => $order['date_purchased'],
+        'orders_status' => $order_status['orders_status_name'],
+        'last_modified' => $order['last_modified'],
+        'total' => strip_tags($order_total['text']),
+        'shipping_method' => ((substr($shipping_method['title'], -1) == ':') ? substr(strip_tags($shipping_method['title']), 0, -1) : strip_tags($shipping_method['title'])),
+      ];
+
+      $this->customer = [
+        'id' => $order['customers_id'],
+        'name' => $order['customers_name'],
+        'company' => $order['customers_company'],
+        'street_address' => $order['customers_street_address'],
+        'suburb' => $order['customers_suburb'],
+        'city' => $order['customers_city'],
+        'postcode' => $order['customers_postcode'],
+        'state' => $order['customers_state'],
+        'country' => ['title' => $order['customers_country']],
+        'format_id' => $order['customers_address_format_id'],
+        'telephone' => $order['customers_telephone'],
+        'email_address' => $order['customers_email_address'],
+      ];
+
+      $this->delivery = [
+        'name' => trim($order['delivery_name']),
+        'company' => $order['delivery_company'],
+        'street_address' => $order['delivery_street_address'],
+        'suburb' => $order['delivery_suburb'],
+        'city' => $order['delivery_city'],
+        'postcode' => $order['delivery_postcode'],
+        'state' => $order['delivery_state'],
+        'country' => [ 'title' => $order['delivery_country']],
+        'format_id' => $order['delivery_address_format_id']];
+
+      if (empty($this->delivery['name']) && empty($this->delivery['street_address'])) {
+        $this->delivery = false;
       }
 
-      $this->customer = array('name' => $order['customers_name'],
-                              'company' => $order['customers_company'],
-                              'street_address' => $order['customers_street_address'],
-                              'suburb' => $order['customers_suburb'],
-                              'city' => $order['customers_city'],
-                              'postcode' => $order['customers_postcode'],
-                              'state' => $order['customers_state'],
-                              'country' => $order['customers_country'],
-                              'format_id' => $order['customers_address_format_id'],
-                              'telephone' => $order['customers_telephone'],
-                              'email_address' => $order['customers_email_address']);
+      $this->billing = [
+        'name' => $order['billing_name'],
+        'company' => $order['billing_company'],
+        'street_address' => $order['billing_street_address'],
+        'suburb' => $order['billing_suburb'],
+        'city' => $order['billing_city'],
+        'postcode' => $order['billing_postcode'],
+        'state' => $order['billing_state'],
+        'country' => ['title' => $order['billing_country']],
+        'format_id' => $order['billing_address_format_id'],
+      ];
 
-      $this->delivery = array('name' => $order['delivery_name'],
-                              'company' => $order['delivery_company'],
-                              'street_address' => $order['delivery_street_address'],
-                              'suburb' => $order['delivery_suburb'],
-                              'city' => $order['delivery_city'],
-                              'postcode' => $order['delivery_postcode'],
-                              'state' => $order['delivery_state'],
-                              'country' => $order['delivery_country'],
-                              'format_id' => $order['delivery_address_format_id']);
-
-      $this->billing = array('name' => $order['billing_name'],
-                             'company' => $order['billing_company'],
-                             'street_address' => $order['billing_street_address'],
-                             'suburb' => $order['billing_suburb'],
-                             'city' => $order['billing_city'],
-                             'postcode' => $order['billing_postcode'],
-                             'state' => $order['billing_state'],
-                             'country' => $order['billing_country'],
-                             'format_id' => $order['billing_address_format_id']);
-
-      $index = 0;
-      $orders_products_query = tep_db_query("select orders_products_id, products_name, products_model, products_price, products_tax, products_quantity, final_price from " . TABLE_ORDERS_PRODUCTS . " where orders_id = '" . (int)$order_id . "'");
+      $orders_products_query = tep_db_query("SELECT orders_products_id, products_id, products_name, products_model, products_price, products_tax, products_quantity, final_price FROM orders_products WHERE orders_id = " . (int)$order_id);
       while ($orders_products = tep_db_fetch_array($orders_products_query)) {
-        $this->products[$index] = array('qty' => $orders_products['products_quantity'],
-                                        'name' => $orders_products['products_name'],
-                                        'model' => $orders_products['products_model'],
-                                        'tax' => $orders_products['products_tax'],
-                                        'price' => $orders_products['products_price'],
-                                        'final_price' => $orders_products['final_price']);
+        $current = [
+          'qty' => $orders_products['products_quantity'],
+          'id' => $orders_products['products_id'],
+          'name' => $orders_products['products_name'],
+          'model' => $orders_products['products_model'],
+          'tax' => $orders_products['products_tax'],
+          'price' => $orders_products['products_price'],
+          'final_price' => $orders_products['final_price'],
+        ];
 
-        $subindex = 0;
-        $attributes_query = tep_db_query("select products_options, products_options_values, options_values_price, price_prefix from " . TABLE_ORDERS_PRODUCTS_ATTRIBUTES . " where orders_id = '" . (int)$order_id . "' and orders_products_id = '" . (int)$orders_products['orders_products_id'] . "'");
-        if (tep_db_num_rows($attributes_query)) {
-          while ($attributes = tep_db_fetch_array($attributes_query)) {
-            $this->products[$index]['attributes'][$subindex] = array('option' => $attributes['products_options'],
-                                                                     'value' => $attributes['products_options_values'],
-                                                                     'prefix' => $attributes['price_prefix'],
-                                                                     'price' => $attributes['options_values_price']);
-
-            $subindex++;
-          }
+        $attributes_query = tep_db_query("SELECT products_options, products_options_values, options_values_price, price_prefix FROM orders_products_attributes WHERE orders_id = " . (int)$order_id . " AND orders_products_id = " . (int)$orders_products['orders_products_id']);
+        while ($attributes = tep_db_fetch_array($attributes_query)) {
+          $current['attributes'][] = [
+            'option' => $attributes['products_options'],
+            'value' => $attributes['products_options_values'],
+            'prefix' => $attributes['price_prefix'],
+            'price' => $attributes['options_values_price'],
+          ];
         }
-        $index++;
+
+        $this->info['tax_groups']["{$current['tax']}"] = '1';
+
+        $this->products[] = $current;
       }
     }
+
   }
-?>

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -154,40 +154,13 @@ if ( typeof jQuery.ui == 'undefined' ) {
             <legend><?php echo ENTRY_PAYMENT_METHOD; ?></legend>
 
             <p><?php echo $order->info['payment_method']; ?></p>
-
-<?php
-    if (tep_not_null($order->info['cc_type']) || tep_not_null($order->info['cc_owner']) || tep_not_null($order->info['cc_number'])) {
-?>
-
-            <table border="0" cellspacing="0" cellpadding="0">
-              <tr>
-                <td><?php echo ENTRY_CREDIT_CARD_TYPE; ?></td>
-                <td><?php echo $order->info['cc_type']; ?></td>
-              </tr>
-              <tr>
-                <td><?php echo ENTRY_CREDIT_CARD_OWNER; ?></td>
-                <td><?php echo $order->info['cc_owner']; ?></td>
-              </tr>
-              <tr>
-                <td><?php echo ENTRY_CREDIT_CARD_NUMBER; ?></td>
-                <td><?php echo $order->info['cc_number']; ?></td>
-              </tr>
-              <tr>
-                <td><?php echo ENTRY_CREDIT_CARD_EXPIRES; ?></td>
-                <td><?php echo $order->info['cc_expires']; ?></td>
-              </tr>
-            </table>
-
-<?php
-    }
-?>
           </fieldset>
         </td>
         <td width="33%" valign="top">
           <fieldset style="border: 0; height: 100%;">
             <legend><?php echo ENTRY_STATUS; ?></legend>
 
-            <p><?php echo $order->info['status'] . '<br />' . (empty($order->info['last_modified']) ? tep_datetime_short($order->info['date_purchased']) : tep_datetime_short($order->info['last_modified'])); ?></p>
+            <p><?php echo $order->info['orders_status'] . '<br />' . tep_datetime_short($order->info['last_modified'] ?? $order->info['date_purchased']); ?></p>
           </fieldset>
         </td>
         <td width="33%" valign="top">


### PR DESCRIPTION
There is currently a display error because the admin version of the order class loads the country differently.  This updates the admin version to match  the catalog version.

Longer term, the solution is probably to simply eliminate the admin version of the class.  Then it will just use the catalog version and we won't have to worry about this kind of inconsistency.  But to avoid the problems that occur when people fail to delete the file, just updating it for now.  We can revisit after the 1.0.6.0 release.
