### PR TITLE
URL links must be urlencoded first before being outputted in the html

### DIFF
--- a/admin/includes/functions/general.php
+++ b/admin/includes/functions/general.php
@@ -91,7 +91,7 @@
     $get_url = '';
     foreach ($_GET as $key => $value) {
       if (!in_array($key, $excludes)) {
-        $get_url .= $key . '=' . $value . '&';
+        $get_url .= urlencode($key) . '=' . urlencode($value) . '&';
       }
     }
 


### PR DESCRIPTION
URL links echoed in HTML attributes must be URL encoded otherwise they can escape their context.
In the case of `onclick` and similar executable attributes, the URL might contain payload that can execute arbitrary JS code.

HTML sanitization of the URL does not suffice as the HTML parser automatically decodes HTML encoded characters in HTML attributes.

Issue: #1039


